### PR TITLE
bugfix for hooks using main markets context hook

### DIFF
--- a/src/hooks/markets/useExchangeRates.ts
+++ b/src/hooks/markets/useExchangeRates.ts
@@ -18,9 +18,10 @@ export const useExchangeRates = (): ExchangeRates => {
 	const { library, account, chainId } = useWeb3React()
 	const markets = useMarkets()
 
-	const enabled = !!bao && !!markets && !!account
+	const enabled = markets?.length > 0 && !!bao && !!account
+	const mids = markets?.map(market => market.mid)
 	const { data: exchangeRates, refetch } = useQuery(
-		['@/hooks/markets/useExchangeRates', providerKey(library, account, chainId), { enabled }],
+		['@/hooks/markets/useExchangeRates', providerKey(library, account, chainId), { enabled, mids }],
 		async () => {
 			const tokenContracts = markets.map((market: ActiveSupportedMarket) => market.marketContract)
 			const multiCallContext = MultiCall.createCallContext(

--- a/src/hooks/markets/useMarkets.ts
+++ b/src/hooks/markets/useMarkets.ts
@@ -19,7 +19,7 @@ export const useAccountMarkets = (): ActiveSupportedMarket[] | undefined => {
 	const { library, account, chainId } = useWeb3React()
 	const comptroller = useContract<Comptroller>('Comptroller')
 
-	const enabled = !!library && !!comptroller && !!markets
+	const enabled = markets?.length > 0 && !!library && !!comptroller
 	const mids = markets?.map(market => market.mid)
 	const { data: accountMarkets, refetch } = useQuery(
 		['@/hooks/markets/useAccountMarkets', providerKey(library, account, chainId), { enabled, mids }],

--- a/src/hooks/markets/useMarketsTVL.ts
+++ b/src/hooks/markets/useMarketsTVL.ts
@@ -16,7 +16,7 @@ export const useMarketsTVL = () => {
 	const { prices } = useMarketPrices() // TODO- use market.price instead of market prices hook
 	const stabilizer = useContract<Stabilizer>('Stabilizer')
 
-	const enabled = !!markets && !!stabilizer && !!prices
+	const enabled = markets?.length > 0 && !!stabilizer && !!prices
 	const mids = markets?.map(market => market.mid)
 	const { data: tvl, refetch } = useQuery(
 		['@/hooks/markets/useMarketsTVL', providerKey(library, account, chainId), { enabled, prices, mids }],

--- a/src/pages/markets/components/MarketList.tsx
+++ b/src/pages/markets/components/MarketList.tsx
@@ -126,6 +126,7 @@ const MarketListItemCollateral: React.FC<MarketListItemProps> = ({
 	const suppliedUnderlying = useMemo(() => {
 		const supply = supplyBalances.find(balance => balance.address === market.marketAddress)
 		if (supply === undefined) return BigNumber.from(0)
+		if (exchangeRates[market.marketAddress] === undefined) return BigNumber.from(0)
 		return decimate(supply.balance.mul(exchangeRates[market.marketAddress]))
 	}, [supplyBalances, exchangeRates, market.marketAddress])
 


### PR DESCRIPTION
it was a useQuery query key bug! using the market id `mid` as part of the query key fixes it